### PR TITLE
Enforce PEP8 coding style

### DIFF
--- a/.github/workflows/tiny_dset_test.yml
+++ b/.github/workflows/tiny_dset_test.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install ruff pytest
           pip install -r dset-requirements.txt
+      - name: Run linter
+        run: |
+          ruff check
       - name: Find all the scripts subfolders and execute the testing script
         env:
           SSP_PDR_USR: ${{ secrets.SSP_PDR_USR }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.3.7
+  hooks:
+    # Run the linter.
+    - id: ruff
+    # Run the formatter.
+    - id: ruff-format
+      args: [--check]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ For a lightweight prototype of the functionality included in this repository, pl
 ![image](https://github.com/PolymathicAI/AstroPile/assets/861591/ce55d0d2-045b-4d09-92b0-88a55e6f96fc)
 
 Please see the [Design Document](https://github.com/AstroPile/AstroPile_prototype/blob/main/DESIGN.md) for context about the project.
+
+## How To Contribute
+
+### Code Style
+
+The code should follow the standard [PEP8 Style Guide for Python Code](https://peps.python.org/pep-0008/). This is enforced by using the [ruff](https://docs.astral.sh/ruff/) code linter and formatter. 
+
+To help with maintaining compliance with the format, we provide a `pre-commit` hook that automatically runs `ruff` on the modified code. To install and learn more about `pre-commit`, please refer to [the official documentation](https://pre-commit.com/).

--- a/astropile/utils.py
+++ b/astropile/utils.py
@@ -1,4 +1,3 @@
-import os
 from datasets import DatasetBuilder, Dataset
 from astropy.table import Table, hstack, vstack
 from astropy.coordinates import SkyCoord

--- a/baselines/photo_z/photo_z_wrapper.py
+++ b/baselines/photo_z/photo_z_wrapper.py
@@ -3,8 +3,7 @@ sys.path.append('../')
 import torch
 from pytorch_lightning import LightningDataModule
 from torch.utils.data import Dataset, DataLoader
-from utils import split_dataset, compute_dataset_statistics, normalize_sample, get_nested
-from typing import Any
+from utils import compute_dataset_statistics, normalize_sample, get_nested
 
 class PhotoZWrapper(LightningDataModule):
     def __init__(self, 

--- a/scripts/decals/build_parent_sample.py
+++ b/scripts/decals/build_parent_sample.py
@@ -43,7 +43,6 @@ def _processing_fn(args):
     files = [h5py.File(file, 'r') for file in input_files]
 
     images = []
-    indss = []
     # Loop over the indices and yield the requested data
     for i, id in enumerate(keys):
         # Get the entry from the corresponding file

--- a/scripts/desi/desi.py
+++ b/scripts/desi/desi.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import datasets
-from datasets import Features, Value, Array2D, Sequence
+from datasets import Features, Value, Sequence
 from datasets.data_files import DataFilesPatternsDict
 import itertools
 import h5py

--- a/scripts/sdss/globus_transfer.py
+++ b/scripts/sdss/globus_transfer.py
@@ -1,5 +1,4 @@
 import os
-import numpy as np
 import argparse
 import urllib.request
 from astropy.table import Table, unique

--- a/scripts/sdss/sdss.py
+++ b/scripts/sdss/sdss.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import datasets
-from datasets import Features, Value, Array2D, Sequence
+from datasets import Features, Value, Sequence
 from datasets.data_files import DataFilesPatternsDict
 import itertools
 import h5py


### PR DESCRIPTION
To enforce the [PEP8 Style Guide for Python Code](https://peps.python.org/pep-0008/) in order to help maintaining the repository and guarantee a common coding style, this PR introduces [ruff](https://docs.astral.sh/ruff/) checks and formatting.

- `ruff` is added to the github action. So far, test scripts on the different datasets will only run if the lint and format checks pass.
- `pre-commit` hook is added to help contributors comply with the code style. The pre-commit hook must be installed (c.f. [`pre-commit` documentation](https://pre-commit.com/)). The `pre-commit` only runs checks. It doesn't fix the code style, so no code is edited without the user knowing. However, once installed the pre-commit hook will prevent contributors to commit if their code doesn't pass the checks.

Currently, 14 python files do not pass the format checks. Reformatting these files will induce a large diff which may require its own PR. Otherwise, I can add it to this one. This is to be decided.